### PR TITLE
Updated AXI-lite RAM to pass a formal verification check

### DIFF
--- a/rtl/axil_ram.v
+++ b/rtl/axil_ram.v
@@ -38,7 +38,7 @@ module axil_ram #
     // Width of wstrb (width of data bus in words)
     parameter STRB_WIDTH = (DATA_WIDTH/8),
     // Extra pipeline register on output
-    parameter PIPELINE_OUTPUT = 0
+    parameter PIPELINE_OUTPUT = 1
 )
 (
     input  wire                   clk,
@@ -98,6 +98,7 @@ assign s_axil_rvalid = PIPELINE_OUTPUT ? s_axil_rvalid_pipe_reg : s_axil_rvalid_
 
 integer i, j;
 
+`ifndef FORMAL
 initial begin
     // two nested loops for smaller number of iterations per loop
     // workaround for synthesizer complaints about large loop counts
@@ -107,6 +108,7 @@ initial begin
         end
     end
 end
+`endif
 
 always @* begin
     mem_wr_en = 1'b0;
@@ -118,10 +120,12 @@ always @* begin
     if (s_axil_awvalid && s_axil_wvalid && (!s_axil_bvalid || s_axil_bready) && (!s_axil_awready && !s_axil_wready)) begin
         s_axil_awready_next = 1'b1;
         s_axil_wready_next = 1'b1;
-        s_axil_bvalid_next = 1'b1;
-
         mem_wr_en = 1'b1;
     end
+
+    if (s_axil_awvalid && s_axil_wvalid && (!s_axil_bvalid || s_axil_bready) && (s_axil_awready && s_axil_wready))
+        s_axil_bvalid_next = 1'b1;
+
 end
 
 always @(posedge clk) begin


### PR DESCRIPTION
These few updates were required to get your AXI-lite design to pass a formal verification check.

At issue is the fact that BVALID (or RVALID for that matter) cannot be set prior to both AWVALID && AWREADY and WVALID && WREADY have passed.  According to the AXI space,

> The slave must wait for both ARVALID and ARREADY to be asserted before it asserts RVALID to indicate that valid data is available

and again,

> The slave must wait for AWVALID, AWREADY, WVALID, and WREADY to be asserted before asserting BVALID.

These changes bring the design back into compliance.

You may also need to remove the `PIPELINE_OUTPUT` option, since this slave is only legal if `PIPELINE_OUTPUT` is set.

Dan