### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,9 +374,9 @@ registers can be individually bypassed.
 ### Source Files
 
     rtl/arbiter.v                   : Parametrizable arbiter
-    rtl/axi_adapter.v               : AXI lite width converter
-    rtl/axi_adapter_rd.v            : AXI lite width converter (read)
-    rtl/axi_adapter_wr.v            : AXI lite width converter (write)
+    rtl/axi_adapter.v               : AXI width converter
+    rtl/axi_adapter_rd.v            : AXI width converter (read)
+    rtl/axi_adapter_wr.v            : AXI width converter (write)
     rtl/axi_axil_adapter.v          : AXI to AXI lite converter
     rtl/axi_axil_adapter_rd.v       : AXI to AXI lite converter (read)
     rtl/axi_axil_adapter_wr.v       : AXI to AXI lite converter (write)


### PR DESCRIPTION
axi_adapter* should be AXI width converter, not AXI Lite.

Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>