### PR TITLE
axi_adapter: fix compilation with verilator

### DIFF
--- a/rtl/axi_adapter_rd.v
+++ b/rtl/axi_adapter_rd.v
@@ -121,6 +121,7 @@ parameter S_WORD_SIZE = S_DATA_WIDTH/S_WORD_WIDTH;
 parameter M_WORD_SIZE = M_DATA_WIDTH/M_WORD_WIDTH;
 parameter S_BURST_SIZE = $clog2(S_STRB_WIDTH);
 parameter M_BURST_SIZE = $clog2(M_STRB_WIDTH);
+parameter BURST_SIZE_DIFF = EXPAND ? 0 : S_BURST_SIZE - M_BURST_SIZE;
 
 // output bus is wider
 parameter EXPAND = M_STRB_WIDTH > S_STRB_WIDTH;
@@ -465,11 +466,11 @@ always @* begin
                     burst_size_next = s_axi_arsize;
                     if (s_axi_arsize > M_BURST_SIZE) begin
                         // need to adjust burst size
-                        if ({s_axi_arlen, {S_BURST_SIZE-M_BURST_SIZE{1'b1}}} >> (S_BURST_SIZE-s_axi_arsize) > 255) begin
+                        if ({s_axi_arlen, {BURST_SIZE_DIFF{1'b1}}} >> (S_BURST_SIZE-s_axi_arsize) > 255) begin
                             // limit burst length to max
                             master_burst_next = 8'd255;
                         end else begin
-                            master_burst_next = {s_axi_arlen, {S_BURST_SIZE-M_BURST_SIZE{1'b1}}} >> (S_BURST_SIZE-s_axi_arsize);
+                            master_burst_next = {s_axi_arlen, {BURST_SIZE_DIFF{1'b1}}} >> (S_BURST_SIZE-s_axi_arsize);
                         end
                         master_burst_size_next = M_BURST_SIZE;
                         m_axi_arlen_next = master_burst_next;
@@ -528,11 +529,11 @@ always @* begin
                             m_axi_araddr_next = addr_next;
                             if (burst_size_reg > M_BURST_SIZE) begin
                                 // need to adjust burst size
-                                if ({burst_next, {S_BURST_SIZE-M_BURST_SIZE{1'b1}}} >> (S_BURST_SIZE-burst_size_reg) > 255) begin
+                                if ({burst_next, {BURST_SIZE_DIFF{1'b1}}} >> (S_BURST_SIZE-burst_size_reg) > 255) begin
                                     // limit burst length to max
                                     master_burst_next = 8'd255;
                                 end else begin
-                                    master_burst_next = {burst_next, {S_BURST_SIZE-M_BURST_SIZE{1'b1}}} >> (S_BURST_SIZE-burst_size_reg);
+                                    master_burst_next = {burst_next, {BURST_SIZE_DIFF{1'b1}}} >> (S_BURST_SIZE-burst_size_reg);
                                 end
                                 master_burst_size_next = M_BURST_SIZE;
                                 m_axi_arlen_next = master_burst_next;


### PR DESCRIPTION
Verilator always compiles both parts of code with EXPAND = 0 and 1 - but some parameters were only valid for one of them (because only one of them is actually executed after compilation). This is now fixed by setting safe values of these parameters for the non-active part of the code.
