### PR TITLE
fix numerical overflow in bit shift operation

### DIFF
--- a/rtl/axi_crossbar_rd.v
+++ b/rtl/axi_crossbar_rd.v
@@ -327,6 +327,8 @@ generate
         wire [M_COUNT_P1-1:0] r_grant;
         wire r_grant_valid;
         wire [CL_M_COUNT_P1-1:0] r_grant_encoded;
+        wire [CL_M_COUNT_P1-1 + DATA_WIDTH:0] r_grant_encoded_wide = {{DATA_WIDTH{1'b0}}, r_grant_encoded};
+        wire [CL_M_COUNT_P1-1 + DATA_WIDTH:0] r_grant_encoded_wide_shift = r_grant_encoded_wide * DATA_WIDTH;
 
         arbiter #(
             .PORTS(M_COUNT_P1),
@@ -347,7 +349,7 @@ generate
 
         // read response mux
         wire [S_ID_WIDTH-1:0]  m_axi_rid_mux    = {decerr_m_axi_rid_reg, int_m_axi_rid} >> r_grant_encoded*M_ID_WIDTH;
-        wire [DATA_WIDTH-1:0]  m_axi_rdata_mux  = {{DATA_WIDTH{1'b0}}, int_m_axi_rdata} >> r_grant_encoded*DATA_WIDTH;
+        wire [DATA_WIDTH-1:0]  m_axi_rdata_mux  = {{DATA_WIDTH{1'b0}}, int_m_axi_rdata} >> r_grant_encoded_wide_shift;
         wire [1:0]             m_axi_rresp_mux  = {2'b11, int_m_axi_rresp} >> r_grant_encoded*2;
         wire                   m_axi_rlast_mux  = {decerr_m_axi_rlast_reg, int_m_axi_rlast} >> r_grant_encoded;
         wire [RUSER_WIDTH-1:0] m_axi_ruser_mux  = {{RUSER_WIDTH{1'b0}}, int_m_axi_ruser} >> r_grant_encoded*RUSER_WIDTH;


### PR DESCRIPTION
In `xsim`, the limited bit width of the shift-right argument `r_grant_encoded` causes overflow when the shift amount is multiplied by DATA_WIDTH, leading to a result of always 0 (for example, on a 32-bit wide 3x1 crossbar, `r_grant_encoded` would have a bit width of 2 bits, which is then multiplied by 32, which yields 0 for any value of `r_grant_encoded` that is multiplied and then stuffed back into its 2-bit specified width).

This creates an explicitly sized shift right argument to fix this small compatibility issue. I'm not actually sure if this is a bug is `xsim` (this is the Xilinx Vivado simulator) or if it's an issue with the code; however, empirically, this fixes an issue encountered simulating the code.
