### PR TITLE
add option for initialization file for RAM

### DIFF
--- a/rtl/axi_ram.v
+++ b/rtl/axi_ram.v
@@ -42,7 +42,9 @@ module axi_ram #
     // Width of ID signal
     parameter ID_WIDTH = 8,
     // Extra pipeline register on output
-    parameter PIPELINE_OUTPUT = 0
+    parameter PIPELINE_OUTPUT = 0,
+    // Initialization file
+    parameter MEM_INIT = ""
 )
 (
     input  wire                   clk,
@@ -166,14 +168,19 @@ assign s_axi_rvalid = PIPELINE_OUTPUT ? s_axi_rvalid_pipe_reg : s_axi_rvalid_reg
 integer i, j;
 
 initial begin
-    // two nested loops for smaller number of iterations per loop
-    // workaround for synthesizer complaints about large loop counts
-    for (i = 0; i < 2**VALID_ADDR_WIDTH; i = i + 2**(VALID_ADDR_WIDTH/2)) begin
-        for (j = i; j < i + 2**(VALID_ADDR_WIDTH/2); j = j + 1) begin
-            mem[j] = 0;
+    if (MEM_INIT == "") begin
+        // two nested loops for smaller number of iterations per loop
+        // workaround for synthesizer complaints about large loop counts
+        for (i = 0; i < 2**VALID_ADDR_WIDTH; i = i + 2**(VALID_ADDR_WIDTH/2)) begin
+            for (j = i; j < i + 2**(VALID_ADDR_WIDTH/2); j = j + 1) begin
+                mem[j] = 0;
+            end
         end
+    end else begin
+	    $readmemh(MEM_INIT, mem);
     end
 end
+
 
 always @* begin
     write_state_next = WRITE_STATE_IDLE;


### PR DESCRIPTION
This commit adds a parameter `MEM_INIT` so you can pass a non-zero set of values to pre-populate a RAM's content.

This wouldn't be valid behavior for a silicon tape-out, but at least for Xilinx FPGAs this is supported.