### PR TITLE
WIP: Verilator Compatibility

### DIFF
--- a/rtl/arbiter.v
+++ b/rtl/arbiter.v
@@ -24,6 +24,9 @@ THE SOFTWARE.
 
 // Language: Verilog 2001
 
+// verilator lint_off WIDTH
+// verilator lint_off LITENDIAN
+
 `resetall
 `timescale 1ns / 1ps
 `default_nettype none

--- a/rtl/axil_crossbar_addr.v
+++ b/rtl/axil_crossbar_addr.v
@@ -24,6 +24,10 @@ THE SOFTWARE.
 
 // Language: Verilog 2001
 
+// verilator lint_off WIDTH
+// verilator lint_off LITENDIAN
+// verilator lint_off CASEINCOMPLETE
+
 `resetall
 `timescale 1ns / 1ps
 `default_nettype none

--- a/rtl/axil_crossbar_rd.v
+++ b/rtl/axil_crossbar_rd.v
@@ -24,6 +24,10 @@ THE SOFTWARE.
 
 // Language: Verilog 2001
 
+// verilator lint_off WIDTH
+// verilator lint_off LITENDIAN
+// verilator lint_off UNSIGNED
+
 `resetall
 `timescale 1ns / 1ps
 `default_nettype none

--- a/rtl/axil_crossbar_wr.v
+++ b/rtl/axil_crossbar_wr.v
@@ -24,6 +24,10 @@ THE SOFTWARE.
 
 // Language: Verilog 2001
 
+// verilator lint_off WIDTH
+// verilator lint_off LITENDIAN
+// verilator lint_off UNSIGNED
+
 `resetall
 `timescale 1ns / 1ps
 `default_nettype none

--- a/rtl/priority_encoder.v
+++ b/rtl/priority_encoder.v
@@ -24,6 +24,10 @@ THE SOFTWARE.
 
 // Language: Verilog 2001
 
+// verilator lint_off WIDTH
+// verilator lint_off LITENDIAN
+// verilator lint_off UNOPTFLAT
+
 `resetall
 `timescale 1ns / 1ps
 `default_nettype none

--- a/tb/axil_crossbar/test_axil_crossbar.py
+++ b/tb/axil_crossbar/test_axil_crossbar.py
@@ -242,9 +242,6 @@ def test_axil_crossbar(request, s_count, m_count, data_width):
 
     parameters = {}
 
-    parameters['S_COUNT'] = s_count
-    parameters['M_COUNT'] = m_count
-
     parameters['DATA_WIDTH'] = data_width
     parameters['ADDR_WIDTH'] = 32
     parameters['STRB_WIDTH'] = parameters['DATA_WIDTH'] // 8


### PR DESCRIPTION
These were the changes I needed to make to get `test_axil_crossbar.py` working with verilator, along with using cocotb-bus=0.1.1.
If you think it would be useful, I can try to get all the tests passing in verilator with similar changes.  If you'd rather not apply these changes to the repo, I'll just apply them locally to the modules that I'm using.

* Adds verilator lint_off to RTL so prevent verilator errors.
* Remove missing top-level parameters from tests.