### PR TITLE
Add explicit python3 prefix to all python paths in test suite

### DIFF
--- a/tb/axi_crossbar/Makefile
+++ b/tb/axi_crossbar/Makefile
@@ -83,7 +83,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PARAM_S_COUNT) $(PARAM_M_COUNT)
+	python3 $< -p $(PARAM_S_COUNT) $(PARAM_M_COUNT)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/axi_crossbar/test_axi_crossbar.py
+++ b/tb/axi_crossbar/test_axi_crossbar.py
@@ -243,7 +243,7 @@ def test_axi_crossbar(request, s_count, m_count, data_width):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/axi_interconnect/Makefile
+++ b/tb/axi_interconnect/Makefile
@@ -78,7 +78,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PARAM_S_COUNT) $(PARAM_M_COUNT)
+	python3 $< -p $(PARAM_S_COUNT) $(PARAM_M_COUNT)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/axi_interconnect/test_axi_interconnect.py
+++ b/tb/axi_interconnect/test_axi_interconnect.py
@@ -237,7 +237,7 @@ def test_axi_interconnect(request, s_count, m_count, data_width):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/axil_crossbar/Makefile
+++ b/tb/axil_crossbar/Makefile
@@ -71,7 +71,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PARAM_S_COUNT) $(PARAM_M_COUNT)
+	python3 $< -p $(PARAM_S_COUNT) $(PARAM_M_COUNT)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/axil_crossbar/test_axil_crossbar.py
+++ b/tb/axil_crossbar/test_axil_crossbar.py
@@ -224,7 +224,7 @@ def test_axil_crossbar(request, s_count, m_count, data_width):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/axil_interconnect/Makefile
+++ b/tb/axil_interconnect/Makefile
@@ -66,7 +66,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PARAM_S_COUNT) $(PARAM_M_COUNT)
+	python3 $< -p $(PARAM_S_COUNT) $(PARAM_M_COUNT)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/axil_interconnect/test_axil_interconnect.py
+++ b/tb/axil_interconnect/test_axil_interconnect.py
@@ -224,7 +224,7 @@ def test_axil_interconnect(request, s_count, m_count, data_width):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
             cwd=tests_dir
         ).wait()
 


### PR DESCRIPTION
Allows WSL to properly execute the tests by explicitly stating how the python files should execute. Line ending issues cause WSL to get confused if the repo uses Windows line endings.