### PR TITLE
Fix crossbar locking up after reading to write-only address

### DIFF
--- a/rtl/axi_crossbar_addr.v
+++ b/rtl/axi_crossbar_addr.v
@@ -365,6 +365,7 @@ always @* begin
                     m_decerr_next = 1'b1;
                     m_wc_valid_next = WC_OUTPUT;
                     m_rc_valid_next = 1'b1;
+                    trans_start = 1'b1;
                     state_next = STATE_DECODE;
                 end
             end else begin


### PR DESCRIPTION
When someone tries to read from a write-only region, it doesn't increment trans_count_reg (because it never sets trans_start), but it still gets s_cpl_valid to indicate the end of the transaction (once the DECERR goes through) and tries to decrement the transaction count. This can cause trans_count_reg to overflow and peg the transaction count at the limit, causing the bus to stall.